### PR TITLE
fix: implement __reduce__ function inside DetailedException

### DIFF
--- a/errr/__init__.py
+++ b/errr/__init__.py
@@ -1,7 +1,7 @@
 from .exception import DetailedException
 from .tree import make_tree, exception
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
 def wrap(err_type, *args, **kwargs):
     return err_type.wrap(*args, **kwargs)

--- a/errr/exception.py
+++ b/errr/exception.py
@@ -58,6 +58,11 @@ class DetailedException(Exception, metaclass=DetailedErrorMetaclass):
             return self.details[attr]
         return self.__getattribute__(attr)
 
+    def __reduce__(self):
+        # Need to define it for tblib>=3.2 to work
+        # despite it doing nothing more than calling the parent function
+        return super().__reduce__()
+
     def __setattr__(self, attr, value):
         if attr in self.details:
             self.details[attr] = value

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
      name='errr',
      version=__version__,
      author="Robin De Schepper",
-     author_email="robingilbert.deschepper@unipv.it",
+     author_email="robin@alexandria.sc",
      description="Elegant detailed Python exceptions.",
      long_description=long_description,
      long_description_content_type="text/markdown",


### PR DESCRIPTION
## What has been done

- Implement `__reduce__` inside `DetailedException` so that it works with `tblib`>3.2 
- Bump version
- Update author email

## Related issue
https://github.com/dbbs-lab/bsb/issues/180