### PR TITLE
fix: add missing quotejoin function

### DIFF
--- a/errr/__init__.py
+++ b/errr/__init__.py
@@ -9,3 +9,7 @@ __version__ = "1.2.1"
 
 def wrap(err_type, *args, **kwargs):
     return err_type.wrap(*args, **kwargs)
+
+
+def quotejoin(itr, delim=", ", quote="'", f=str):
+    return delim.join(f"{quote}{f(o)}{quote}" for o in itr)


### PR DESCRIPTION
Add `quotejoin` in `__init__.py` which was there in version 1.2.0 on PyPI 